### PR TITLE
Remove tighter restrictions on XLink arc element

### DIFF
--- a/STC.xsd
+++ b/STC.xsd
@@ -296,8 +296,8 @@
                             </xs:annotation>
                             <xs:complexType>
                                 <xs:attribute ref="xlink:type" fixed="arc"/>
-                                <xs:attribute ref="xlink:from" use="required"/>
-                                <xs:attribute ref="xlink:to" use="required"/>
+                                <xs:attribute ref="xlink:from"/>
+                                <xs:attribute ref="xlink:to"/>
                                 <xs:attribute ref="xlink:title"/>
                                 <xs:attribute ref="xlink:arcrole"/>
                             </xs:complexType>


### PR DESCRIPTION
The current definition made from and to attributes mandatory, going beyond the XLink specification, which lets missing from and to attributes devolve to meaning all locators. Since this is also fine for the purposes of SSP Traceability and concurs with the optional label for locators, this additional restriction can be removed. Fixes #55.